### PR TITLE
Install Ansible via the Ubuntu PPA

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,14 +1,15 @@
 ---
-- name: Enable Ansible PPA repo.
-  apt_repository: deb http://ppa.launchpad.net/ansible/ansible/ubuntu trusty main
-    state: present
-    filename: ansible-ppa
-    
 - name: Add the apt key.
   apt_key:
     keyserver: keyserver.ubuntu.com
     id: 93C4A3FD7BB9C367
     state: present
+
+- name: Enable Ansible PPA repo.
+  apt_repository:
+    repo: deb http://ppa.launchpad.net/ansible/ansible/ubuntu trusty main
+    state: present
+    filename: ansible-ppa
 
 - name: Update apt cache.
   apt: update_cache=true cache_valid_time=86400

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,20 +1,17 @@
 ---
-- name: Enable Backports repository.
-  apt_repository:
-    repo: >-
-      deb http://ftp.debian.org/debian
-      {{ ansible_distribution_release }}-backports main'
+- name: Enable Ansible PPA repo.
+  apt_repository: deb http://ppa.launchpad.net/ansible/ansible/ubuntu trusty main
     state: present
-    filename: "{{ ansible_distribution_release }}_backports"
-  when: ansible_distribution_version | int < 9
+    filename: ansible-ppa
+    
+- name: Add the apt key.
+  apt_key:
+    keyserver: keyserver.ubuntu.com
+    id: 93C4A3FD7BB9C367
+    state: present
 
 - name: Update apt cache.
   apt: update_cache=true cache_valid_time=86400
-
-- name: Set the default_release option for older Debian versions.
-  set_fact:
-    ansible_default_release: "{{ ansible_distribution_release }}-backports"
-  when: ansible_distribution_version | int < 9
 
 - name: Install Ansible.
   apt:


### PR DESCRIPTION
It works for Debian as well, as stated in the official docs: https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#latest-releases-via-apt-debian

This is a much better way of doing it, or else you'll get a very old version of Ansible installed via the official Debian repos.