### PR TITLE
Added support for EL 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,17 @@ env:
     - ROLE_NAME: ansible
   matrix:
     - MOLECULE_DISTRO: centos7
+    - MOLECULE_DISTRO: centos8
     - MOLECULE_DISTRO: fedora29
     - MOLECULE_DISTRO: ubuntu1804
     - MOLECULE_DISTRO: debian9
 
     - MOLECULE_DISTRO: centos7
       MOLECULE_PLAYBOOK: playbook-pip.yml
+
+    # Broken due to https://github.com/geerlingguy/ansible-role-pip/issues/24
+    #- MOLECULE_DISTRO: centos8
+    #  MOLECULE_PLAYBOOK: playbook-pip.yml
 
 install:
   # Install test dependencies.

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,6 +1,14 @@
 ---
-- name: Install Ansible.
+- name: Install Ansible CentOS 6 / 7.
   yum:
     name: ansible
     state: "{{ ansible_package_state }}"
     enablerepo: epel
+  when: ansible_distribution_major_version|int < 8
+
+- name: Install Ansible CentOS 8
+  dnf:
+    name: ansible
+    state: "{{ ansible_package_state }}"
+    enablerepo: epel
+  when: ansible_distribution_major_version|int == 8


### PR DESCRIPTION
Added conditional to check if the distribution major version < 8 and if so, install ansible using yum module

Added conditional to check if the distribution major version == 8 and if so, install ansible using dnf module

[![Build Status](https://travis-ci.org/Project-Alamo/ansible-role-ansible.svg?branch=EL8_Support)](https://travis-ci.org/Project-Alamo/ansible-role-ansible)