### PR TITLE
Add capacity to pass extra args to pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Whether to install Ansible via the system `package` manager (`apt`, `yum`, `dnf`
 
 If `ansible_install_method` is set to `pip`, the specific Ansible version to be installed via Pip. If not set, the latest version of Ansible will be installed.
 
+    ansible_pip_extra_args: ''
+
+Using this variable you'll be able to any pass extra args to pip when installing Ansible
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,3 +6,6 @@ ansible_install_method: package
 
 # Used only if ansible_install_method is 'pip'. If empty, defaults to latest.
 ansible_install_version_pip: ''
+
+# Can be use to pass extra args to pip if needed 
+ansible_pip_extra_args: ''

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,5 +7,5 @@ ansible_install_method: package
 # Used only if ansible_install_method is 'pip'. If empty, defaults to latest.
 ansible_install_version_pip: ''
 
-# Can be use to pass extra args to pip if needed 
+# Can be use to pass extra args to pip if needed
 ansible_pip_extra_args: ''

--- a/tasks/setup-pip.yml
+++ b/tasks/setup-pip.yml
@@ -2,4 +2,5 @@
 - name: Install Ansible via Pip.
   pip:
     name: ansible
+    extra_args: "{{ ansible_pip_extra_args | default(omit) }}"
     version: "{{ ansible_install_version_pip | default(omit) }}"


### PR DESCRIPTION
Hi Jeff,

Here is a small pull request to be able to pass extra args to pip when installing Ansible.

I my case I had to pass this arg to pip : 
```
--no-cache-dir
```
to avoid this kind of error, as I'm running Ansible in a limited-memory environment.

```
TASK [geerlingguy.ansible : Install Ansible via Pip.] *************************************************************************************************************************************************************
fatal: [acme]: FAILED! => {"changed": false, "cmd": ["/usr/bin/pip2", "install", "ansible==2.9.9"], "msg": "stdout: Collecting ansible==2.9.9\n  Downloading https://files.pythonhosted.org/packages/00/5d/e10b83e0e6056dbd5b4809b451a191395175a57e3175ce04e35d9c5fc2a0/ansible-2.9.9.tar.gz (14.2MB)\n\n:stderr: Exception:\nTraceback (most recent call last):\n  File \"/usr/lib/python2.7/dist-packages/pip/_internal/cli/base_command.py\", line 143, in main\n    status = self.run(options, args)\n  File \"/usr/lib/python2.7/dist-packages/pip/_internal/commands/install.py\", line 338, in run\n    resolver.resolve(requirement_set)\n  File \"/usr/lib/python2.7/dist-packages/pip/_internal/resolve.py\", line 102, in resolve\n    self._resolve_one(requirement_set, req)\n  File \"/usr/lib/python2.7/dist-packages/pip/_internal/resolve.py\", line 256, in _resolve_one\n    abstract_dist = self._get_abstract_dist_for(req_to_install)\n  File \"/usr/lib/python2.7/dist-packages/pip/_internal/resolve.py\", line 209, in _get_abstract_dist_for\n    self.require_hashes\n  File \"/usr/lib/python2.7/dist-packages/pip/_internal/operations/prepare.py\", line 283, in prepare_linked_requirement\n    progress_bar=self.progress_bar\n  File \"/usr/lib/python2.7/dist-packages/pip/_internal/download.py\", line 836, in unpack_url\n    progress_bar=progress_bar\n  File \"/usr/lib/python2.7/dist-packages/pip/_internal/download.py\", line 673, in unpack_http_url\n    progress_bar)\n  File \"/usr/lib/python2.7/dist-packages/pip/_internal/download.py\", line 897, in _download_http_url\n    _download_url(resp, link, content_file, hashes, progress_bar)\n  File \"/usr/lib/python2.7/dist-packages/pip/_internal/download.py\", line 617, in _download_url\n    hashes.check_against_chunks(downloaded_chunks)\n  File \"/usr/lib/python2.7/dist-packages/pip/_internal/utils/hashes.py\", line 48, in check_against_chunks\n    for chunk in chunks:\n  File \"/usr/lib/python2.7/dist-packages/pip/_internal/download.py\", line 585, in written_chunks\n    for chunk in chunks:\n  File \"/usr/lib/python2.7/dist-packages/pip/_internal/utils/ui.py\", line 159, in iter\n    for x in it:\n  File \"/usr/lib/python2.7/dist-packages/pip/_internal/download.py\", line 574, in resp_read\n    decode_content=False):\n  File \"/usr/share/python-wheels/urllib3-1.24.1-py2.py3-none-any.whl/urllib3/response.py\", line 494, in stream\n    data = self.read(amt=amt, decode_content=decode_content)\n  File \"/usr/share/python-wheels/urllib3-1.24.1-py2.py3-none-any.whl/urllib3/response.py\", line 442, in read\n    data = self._fp.read(amt)\n  File \"/usr/share/python-wheels/CacheControl-0.11.7-py2.py3-none-any.whl/cachecontrol/filewrapper.py\", line 63, in read\n    self._close()\n  File \"/usr/share/python-wheels/CacheControl-0.11.7-py2.py3-none-any.whl/cachecontrol/filewrapper.py\", line 50, in _close\n    self.__callback(self.__buf.getvalue())\n  File \"/usr/share/python-wheels/CacheControl-0.11.7-py2.py3-none-any.whl/cachecontrol/controller.py\", line 275, in cache_response\n    self.serializer.dumps(request, response, body=body),\n  File \"/usr/share/python-wheels/CacheControl-0.11.7-py2.py3-none-any.whl/cachecontrol/serialize.py\", line 87, in dumps\n    ).encode(\"utf8\"),\nMemoryError\n"}
```