### PR TITLE
Fixes for epel repo name, and allow to specify a pip executable name

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If `ansible_install_method` is set to `pip`, the extra arguments to be given to 
 
 if `ansible_install_method` is set to `pip`, this is the path to the pip executable, in case your platform doesn't find the right name.
 
-    ansible_epel_name: 'epel'
+    ansible_epel_repo_name: 'epel'
 
 if `ansible_install_method` is set to `package` and you are on a RHEL machine, and your local satellite server admins decided to name the epel repository something other than epel, this variable gives you the opportunity to provide the right name.
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ If `ansible_install_method` is set to `pip`, the specific Ansible version to be 
 
 If `ansible_install_method` is set to `pip`, the extra arguments to be given to `pip` are listed here. If not set, no extra arguments are given.
 
+    ansible_pip_executable: ''
+
+if `ansible_install_method` is set to `pip`, this is the path to the pip executable, in case your platform doesn't find the right name.
+
+    ansible_epel_name: 'epel'
+
+if `ansible_install_method` is set to `package` and you are on a RHEL machine, and your local satellite server admins decided to name the epel repository something other than epel, this variable gives you the opportunity to provide the right name.
+
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,4 +14,4 @@ ansible_install_pip_extra_args: ''
 ansible_pip_executable: ''
 
 # name of epel repo if it isn't standard
-ansible_epel_name: 'epel'
+ansible_epel_repo_name: 'epel'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,3 +9,9 @@ ansible_install_version_pip: ''
 
 # Which extra arguments should be gived to pip
 ansible_install_pip_extra_args: ''
+
+# path to pip executable to use
+ansible_pip_executable: ''
+
+# name of epel repo if it isn't standard
+ansible_epel_name: 'epel'

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -3,4 +3,4 @@
   package:
     name: ansible
     state: "{{ ansible_package_state }}"
-    enablerepo: epel
+    enablerepo: "{{ ansible_epel_name }}"

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -3,4 +3,4 @@
   package:
     name: ansible
     state: "{{ ansible_package_state }}"
-    enablerepo: "{{ ansible_epel_name }}"
+    enablerepo: "{{ ansible_epel_repo_name }}"

--- a/tasks/setup-pip.yml
+++ b/tasks/setup-pip.yml
@@ -2,5 +2,6 @@
 - name: Install Ansible via Pip.
   pip:
     name: ansible
+    executable: "{{ ansible_pip_executable | default(omit) }}"
     version: "{{ ansible_install_version_pip | default(omit) }}"
     extra_args: "{{ ansible_install_pip_extra_args | default(omit) }}"


### PR DESCRIPTION
So our local satellite server doesn't name the epel repository epel. which caused a problem on RHEL using the package install.  Also, on RHEL trying to use the pip install would fail, because it would try to use `pip` instead of `pip3`.  This pull request fixes both of these issues by allowing you to specify these parameters to the role and override defaults.